### PR TITLE
Include a prefix based on app label and model name in the view names...

### DIFF
--- a/admin_actions/admin.py
+++ b/admin_actions/admin.py
@@ -8,6 +8,13 @@ class ActionsModelAdmin(ModelAdmin):
     actions_row = ()
     actions_detail = ()
 
+    def get_admin_view_prefix(self):
+        opts = self.model._meta
+        return f'{opts.app_label}_{opts.model_name}'
+
+    def get_method_view_name(self, method_name):
+        return f'{self.get_admin_view_prefix()}_{method_name}'
+
     def actions_holder(self, instance):
         actions = []
 
@@ -16,7 +23,7 @@ class ActionsModelAdmin(ModelAdmin):
 
             actions.append({
                 'title': getattr(method, 'short_description', method_name),
-                'path': reverse('admin:' + method_name, args=(instance.pk, ))
+                'path': reverse('admin:' + self.get_method_view_name(method_name), args=(instance.pk, ))
             })
 
         return render_to_string('admin/change_list_item_object_tools.html', context={
@@ -37,20 +44,20 @@ class ActionsModelAdmin(ModelAdmin):
         for method_name in self.actions_row:
             method = getattr(self, method_name)
             action_row_urls.append(
-                path(getattr(method, 'url_path', method_name) + '/<path:pk>/', self.admin_site.admin_view(method), name=method_name))
+                path(getattr(method, 'url_path', method_name) + '/<path:pk>/', self.admin_site.admin_view(method), name=self.get_method_view_name(method_name)))
 
         action_detail_urls = []
         for method_name in self.actions_detail:
             method = getattr(self, method_name)
             action_detail_urls.append(
-                path(getattr(method, 'url_path', method_name) + '/<path:pk>/', self.admin_site.admin_view(method), name=method_name))
+                path(getattr(method, 'url_path', method_name) + '/<path:pk>/', self.admin_site.admin_view(method), name=self.get_method_view_name(method_name)))
 
         action_list_urls = []
         for method_name in self.actions_list:
             method = getattr(self, method_name)
 
             action_list_urls.append(
-                path(getattr(method, 'url_path', method_name), self.admin_site.admin_view(method), name=method_name)
+                path(getattr(method, 'url_path', method_name), self.admin_site.admin_view(method), name=self.get_method_view_name(method_name))
             )
 
         return action_list_urls + action_row_urls + action_detail_urls + urls
@@ -65,7 +72,7 @@ class ActionsModelAdmin(ModelAdmin):
 
             actions.append({
                 'title': getattr(method, 'short_description', method_name),
-                'path': reverse('admin:' + method_name, args=(object_id, ))
+                'path': reverse('admin:' + self.get_method_view_name(method_name), args=(object_id, ))
             })
 
         extra_context.update({
@@ -84,7 +91,7 @@ class ActionsModelAdmin(ModelAdmin):
 
             actions.append({
                 'title': getattr(method, 'short_description', method_name),
-                'path': reverse('admin:' + method_name)
+                'path': reverse('admin:' + self.get_method_view_name(method_name))
             })
 
         extra_context.update({

--- a/admin_actions/admin.py
+++ b/admin_actions/admin.py
@@ -46,7 +46,7 @@ class ActionsModelAdmin(ModelAdmin):
         for method_name in self.actions_row:
             method = getattr(self, method_name)
             action_row_urls.append(
-                path(route=join(getattr(method, 'url_path', method_name), '<path:pk>'),
+                path(route=join('<path:pk>', getattr(method, 'url_path', method_name)),
                      view=self.admin_site.admin_view(method),
                      name=self.get_method_view_name(method_name))
             )
@@ -55,7 +55,7 @@ class ActionsModelAdmin(ModelAdmin):
         for method_name in self.actions_detail:
             method = getattr(self, method_name)
             action_detail_urls.append(
-                path(route=join(getattr(method, 'url_path', method_name), '<path:pk>'),
+                path(route=join('<path:pk>', getattr(method, 'url_path', method_name)),
                      view=self.admin_site.admin_view(method),
                      name=self.get_method_view_name(method_name))
             )

--- a/admin_actions/admin.py
+++ b/admin_actions/admin.py
@@ -1,3 +1,5 @@
+from os.path import join
+
 from django.contrib.admin import ModelAdmin
 from django.template.loader import render_to_string
 from django.urls import path, reverse
@@ -44,13 +46,19 @@ class ActionsModelAdmin(ModelAdmin):
         for method_name in self.actions_row:
             method = getattr(self, method_name)
             action_row_urls.append(
-                path(getattr(method, 'url_path', method_name) + '/<path:pk>/', self.admin_site.admin_view(method), name=self.get_method_view_name(method_name)))
+                path(route=join(getattr(method, 'url_path', method_name), '<path:pk>'),
+                     view=self.admin_site.admin_view(method),
+                     name=self.get_method_view_name(method_name))
+            )
 
         action_detail_urls = []
         for method_name in self.actions_detail:
             method = getattr(self, method_name)
             action_detail_urls.append(
-                path(getattr(method, 'url_path', method_name) + '/<path:pk>/', self.admin_site.admin_view(method), name=self.get_method_view_name(method_name)))
+                path(route=join(getattr(method, 'url_path', method_name), '<path:pk>'),
+                     view=self.admin_site.admin_view(method),
+                     name=self.get_method_view_name(method_name))
+            )
 
         action_list_urls = []
         for method_name in self.actions_list:

--- a/admin_actions/admin.py
+++ b/admin_actions/admin.py
@@ -75,7 +75,8 @@ class ActionsModelAdmin(ModelAdmin):
             method = getattr(self, method_name)
 
             action_list_urls.append(
-                path(getattr(method, 'url_path', method_name), self.admin_site.admin_view(method),
+                path(route=urljoin(getattr(method, 'url_path', method_name)),
+                     view=self.admin_site.admin_view(method),
                      name=self.get_method_view_name(method_name))
             )
 


### PR DESCRIPTION
…for the methods

In case two different admins use the same method name for an action. For example:
```python
class SomeAdminMixin(admin.ModelAdmin):
    actions_list = ['do_all']
    def do_all(self, request):
      # do something
      return redirect(...)

class Model1Admin(SomeAdminMixin):
  pass

class Model2Admin(SomeAdminMixin):
  pass
```

In the current setup, view names from the second admin override the view names from the first admin since they are both the same. I added a prefix to the view names based on the model's app label and name, so the view names don't overlap.
